### PR TITLE
Fix swift pusher beams

### DIFF
--- a/packages/pusher_beams_ios/ios/Classes/SwiftPusherBeamsPlugin.swift
+++ b/packages/pusher_beams_ios/ios/Classes/SwiftPusherBeamsPlugin.swift
@@ -38,7 +38,13 @@ public class SwiftPusherBeamsPlugin: FlutterPluginAppLifeCycleDelegate, FlutterP
 
     @nonobjc public override func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         print("application.didReceiveRemoteNotification: \(userInfo)")
-        beamsClient?.handleNotification(userInfo: userInfo)
+        let remoteNotificationType = beamsClient?.handleNotification(userInfo: userInfo)
+        if remoteNotificationType == .ShouldIgnore {
+            completionHandler(.noData)
+            return
+        }
+
+        completionHandler(.newData)
     }
 
     public override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable: Any] = [:]) -> Bool {
@@ -146,6 +152,12 @@ public class SwiftPusherBeamsPlugin: FlutterPluginAppLifeCycleDelegate, FlutterP
     }
     
     public override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        let remoteNotificationType = beamsClient?.handleNotification(userInfo: notification.request.content.userInfo)
+        if remoteNotificationType == .ShouldIgnore {
+            completionHandler([])
+            return
+        }
+
         if (messageDidReceiveInTheForegroundCallback != nil && SwiftPusherBeamsPlugin.callbackHandler != nil) {
             let pusherMessage: [String : Any] = [
                 "title": notification.request.content.title,
@@ -157,11 +169,17 @@ public class SwiftPusherBeamsPlugin: FlutterPluginAppLifeCycleDelegate, FlutterP
                 print("SwiftPusherBeamsPlugin: message received: \(pusherMessage)")
             })
         }
+
+        if #available(iOS 14.0, *) {
+            completionHandler([.list, .banner, .sound, .badge])
+        } else {
+            completionHandler([.alert, .sound, .badge])
+        }
     }
 
     public override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         // Handle the user interaction with the notification
-        // Not Implemented yet
+        completionHandler()
     }
     
 }


### PR DESCRIPTION
**Summary**
Fix iOS notification lifecycle handling in `pusher_beams_ios` to comply with native callback requirements and restore reliable push behavior in Flutter apps.

**What changed**
- Fixed `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`
  - now calls `completionHandler(.noData/.newData)`
  - prevents unfinished background notification callbacks
- Fixed `userNotificationCenter(_:willPresent:withCompletionHandler:)`
  - now filters internal Pusher notifications via `handleNotification(...)`
  - forwards foreground payload to Dart callback as before
  - now explicitly calls `completionHandler(...)` so foreground notifications can be presented correctly
- Fixed `userNotificationCenter(_:didReceive:withCompletionHandler:)`
  - now calls `completionHandler()`
  - removes empty native response handler

**Why**
The previous iOS implementation left `completionHandler` unresolved in multiple notification callbacks. That can cause:
- random force close / unstable behavior on some iOS devices
- foreground notifications not appearing
- inconsistent push handling between app states

**Impact**
This makes `pusher_beams_ios` safer to use with apps that rely on Beams push notifications, especially on iOS devices where notification lifecycle handling is stricter.

**Recommended app-side follow-up**
Apps consuming this plugin should keep their `AppDelegate` notification handling minimal and pass through to `super` instead of adding workaround timers or manual completion fallbacks.